### PR TITLE
Fixed localonlypatch error on 18362.267 x64

### DIFF
--- a/TermWrap/Patch.cpp
+++ b/TermWrap/Patch.cpp
@@ -130,7 +130,11 @@ void LocalOnlyPatch(ZydisDecoder* decoder, DWORD64 RVA, DWORD64 base, DWORD64 ta
 			operands[1].type == ZYDIS_OPERAND_TYPE_REGISTER &&
 			operands[1].reg.value == ZYDIS_REGISTER_RIP &&
 			target == IP + operands[0].imm.value.u)
-		{
+		{   
+			while (ZYAN_SUCCESS(ZydisDecoderDecodeFull(decoder, (void*)IP, length, &instruction, operands)) && instruction.mnemonic == ZYDIS_MNEMONIC_MOV) {
+                IP += instruction.length;
+                length -= instruction.length;
+            }
 			if (!ZYAN_SUCCESS(ZydisDecoderDecodeInstruction(decoder, (ZydisDecoderContext*)0, (void*)IP, length, &instruction)) ||
 				instruction.mnemonic != ZYDIS_MNEMONIC_TEST) break;
 


### PR DESCRIPTION
[termsrv (2).zip](https://github.com/user-attachments/files/15847918/termsrv.2.zip)
![image](https://github.com/llccd/RDPWrapOffsetFinder/assets/102934154/b4129f87-c248-43cf-ae63-fa17248c9459)
sync from [https://github.com/llccd/RDPWrapOffsetFinder/pull/13](https://github.com/llccd/RDPWrapOffsetFinder/pull/13)