### PR TITLE
Fix total failure on 10.0.26100.7523

### DIFF
--- a/TermWrap/Patch.cpp
+++ b/TermWrap/Patch.cpp
@@ -719,7 +719,8 @@ void patch(HMODULE hMod)
 
 	auto pImportDirectory = pNT->OptionalHeader.DataDirectory + IMAGE_DIRECTORY_ENTRY_IMPORT;
 	auto pImportDescriptor = (PIMAGE_IMPORT_DESCRIPTOR)(base + pImportDirectory->VirtualAddress);
-	auto pImportImage = findImportImage(pImportDescriptor, base, "msvcrt.dll");
+	auto pImportImage = findImportImage(pImportDescriptor, base, "api-ms-win-crt-string-l1-1-0.dll");
+	if (!pImportImage) pImportImage = findImportImage(pImportDescriptor, base, "msvcrt.dll");
 	if (!pImportImage) return;
 	auto memset_addr = findImportFunction(pImportImage, base, "memset");
 


### PR DESCRIPTION
termsrv.dll no longer references msvcrt.dll directly.

It now resolves the import via an API table lookup in kernelbase.dll.

This pull request adds the required resolver to ensure we don't break once 7523 lands in the retail branch.